### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/edu/mit/ll/d4m/db/cloud/util/ArgumentChecker.java
+++ b/src/main/java/edu/mit/ll/d4m/db/cloud/util/ArgumentChecker.java
@@ -9,8 +9,11 @@ package edu.mit.ll.d4m.db.cloud.util;
  */
 public class ArgumentChecker {
 	  private static final String NULL_ARG_MSG = "argument was null";
-	  
-	  public static void notNull(final Object arg1) {
+
+	private ArgumentChecker() {
+	}
+
+	public static void notNull(final Object arg1) {
 	    if (arg1 == null)
 	      throw new IllegalArgumentException(NULL_ARG_MSG + ":Is null- arg1? ");
 	  }

--- a/src/main/java/edu/mit/ll/d4m/db/cloud/util/D4mKeyUtil.java
+++ b/src/main/java/edu/mit/ll/d4m/db/cloud/util/D4mKeyUtil.java
@@ -9,13 +9,16 @@ package edu.mit.ll.d4m.db.cloud.util;
  */
 public class D4mKeyUtil {
 
+	private D4mKeyUtil() {
+	}
+
 	/*
-	 * Convert will extract the row key, column family, column qualifier, and value.
-	 * 
-	 * key   Key ( org.apache.accumulo.core.data.Key)
-	 * value Value ( org.apache.accumulo.core.data.Value)
-	 * d4mKey  is the generic object to hold the row, col family, col qualifier, and value
-	 */
+         * Convert will extract the row key, column family, column qualifier, and value.
+         * 
+         * key   Key ( org.apache.accumulo.core.data.Key)
+         * value Value ( org.apache.accumulo.core.data.Value)
+         * d4mKey  is the generic object to hold the row, col family, col qualifier, and value
+         */
 	public static D4mDataObj convert(Object key, Object value, D4mDataObj d4mKey)  {
 	    String rowKey = null; //row key
 		String column = null; //ColumnQualifier

--- a/src/main/java/edu/mit/ll/d4m/db/cloud/util/D4mQueryUtil.java
+++ b/src/main/java/edu/mit/ll/d4m/db/cloud/util/D4mQueryUtil.java
@@ -19,6 +19,9 @@ public class D4mQueryUtil {
 	public static final String POSITIVE_INFINITY_RANGE = "POSITIVE_INFINITY_RANGE";
 	public static final String NEGATIVE_INFINITY_RANGE = "NEGATIVE_INFINITY_RANGE";
 
+	private D4mQueryUtil() {
+	}
+
 
 	public static D4mDataObj whatQueryMethod (String rows, String cols) {
 

--- a/src/main/java/edu/mit/ll/d4m/db/cloud/util/RegExpUtil.java
+++ b/src/main/java/edu/mit/ll/d4m/db/cloud/util/RegExpUtil.java
@@ -16,6 +16,9 @@ public class RegExpUtil {
 	static int i127=127;
 	static String ASCII_127 = Character.toString((char)127);
 
+	private RegExpUtil() {
+	}
+
 	/*
 	 *  str -  String array - eg   a,:,b
 	 *   This array follows the Matlab-like syntax

--- a/src/main/java/edu/mit/ll/graphulo/util/DebugUtil.java
+++ b/src/main/java/edu/mit/ll/graphulo/util/DebugUtil.java
@@ -21,6 +21,9 @@ import java.util.TreeSet;
 public class DebugUtil {
 
 
+  private DebugUtil() {
+  }
+
   public static void printTable(String header, Connector conn, String table, Integer w) {
     if (header != null)
       System.out.println(header);

--- a/src/main/java/edu/mit/ll/graphulo/util/GraphuloUtil.java
+++ b/src/main/java/edu/mit/ll/graphulo/util/GraphuloUtil.java
@@ -60,6 +60,9 @@ public class GraphuloUtil {
   private static final Text EMPTY_TEXT = new Text();
   public static final String OPT_SUFFIX = ".opt.";
 
+  private GraphuloUtil() {
+  }
+
 
   /* Motivation for using -1 argument in String.split() call:
 System.out.println(",".split(",",-1 ).length + Arrays.toString(",".split(",",-1 )));

--- a/src/main/java/edu/mit/ll/graphulo/util/MemMatrixUtil.java
+++ b/src/main/java/edu/mit/ll/graphulo/util/MemMatrixUtil.java
@@ -24,6 +24,9 @@ import java.util.TreeMap;
 public class MemMatrixUtil {
   private static final Logger log = LogManager.getLogger(MemMatrixUtil.class);
 
+  private MemMatrixUtil() {
+  }
+
   /** numIterations >= 0 means use Newton's method with the given numIterations.
    * numIterations < 0 means use an exact LU decomposition to solve for the inverse. */
   public static RealMatrix doInverse(RealMatrix matrix, int numIterations) {

--- a/src/test/java/edu/mit/ll/graphulo/examples/ExampleUtil.java
+++ b/src/test/java/edu/mit/ll/graphulo/examples/ExampleUtil.java
@@ -16,6 +16,9 @@ import java.net.URL;
 public class ExampleUtil {
   private static final Logger log = LogManager.getLogger(ExampleUtil.class);
 
+  private ExampleUtil() {
+  }
+
   public static File getDataFile(String name) {
     URL url = Thread.currentThread().getContextClassLoader().getResource("data/"+name);
     if (url == null)

--- a/src/test/java/edu/mit/ll/graphulo/util/TestUtil.java
+++ b/src/test/java/edu/mit/ll/graphulo/util/TestUtil.java
@@ -32,6 +32,9 @@ import java.util.SortedSet;
 public class TestUtil {
   private static final Logger log = LogManager.getLogger(TestUtil.class);
 
+  private TestUtil() {
+  }
+
 
   public static void createTestTable(Connector conn, String tableName) {
     if (conn.tableOperations().exists(tableName)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.