### PR TITLE
 Floating point numbers should not be tested for equality

### DIFF
--- a/src/main/java/edu/mit/ll/graphulo/Graphulo.java
+++ b/src/main/java/edu/mit/ll/graphulo/Graphulo.java
@@ -2757,7 +2757,7 @@ public class Graphulo {
     matrix.walkInOptimizedOrder(new DefaultRealMatrixPreservingVisitor() {
       @Override
       public void visit(int row, int column, double value) {
-        arr[row * M + column][numiter] = value == 0 ? "    " : String.format("%4.2f", value);
+        arr[row * M + column][numiter] = Double.doubleToRawLongBits(value) == 0 ? "    " : String.format("%4.2f", value);
       }
     });
   }

--- a/src/main/java/edu/mit/ll/graphulo/rowmult/LineRowMultiply.java
+++ b/src/main/java/edu/mit/ll/graphulo/rowmult/LineRowMultiply.java
@@ -133,13 +133,13 @@ public class LineRowMultiply implements RowMultiplyOp {
     dout = !isDirected ? din : mapA.size();
     assert din >= 1 && dout >= 1;
     win = sumValues(mapAT);
-    if (win == 0)
+    if (Double.doubleToRawLongBits(win) == 0)
       return false; // case where weights sum to zero; very rare.
 
     nume = !isDirected ? din * (din-1) / 2 : // undirected: (din choose 2)
         (!includeExtraCycles ? din * dout :  // directed without AAT term: din*dout
             din * dout + din * (din-1));     // directed with AAT term: din*dout + 2*(din choose 2)
-    if (nume == 0)
+    if (Double.doubleToRawLongBits(nume) == 0)
       return false; // no edges emit
     winPerEdge = !isDirected ? win / nume / 2 : win / nume;
     winPerEdgeValue = new Value(Double.toString(winPerEdge).getBytes());

--- a/src/main/java/edu/mit/ll/graphulo/simplemult/MathTwoScalar.java
+++ b/src/main/java/edu/mit/ll/graphulo/simplemult/MathTwoScalar.java
@@ -253,7 +253,7 @@ public class MathTwoScalar extends SimpleTwoScalar {
     if (!keepZero) {
       switch (scalarType) {
         case LONG: if (nnew.longValue() == 0) return null; break;
-        case DOUBLE: if (nnew.doubleValue() == 0) return null; break;
+        case DOUBLE: if (Double.doubleToRawLongBits(nnew.doubleValue()) == 0) return null; break;
         case BIGDECIMAL: if (nnew.equals(BigDecimal.ZERO)) return null; break;
       }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1244 - “Floating point numbers should not be tested for equality”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1244
Please let me know if you have any questions.
Ayman Abdelghany.