### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/src/main/java/edu/mit/ll/d4m/db/cloud/accumulo/AccumuloTableOperations.java
+++ b/src/main/java/edu/mit/ll/d4m/db/cloud/accumulo/AccumuloTableOperations.java
@@ -93,7 +93,7 @@ public class AccumuloTableOperations {
 
 		//Get TServers
 		try {
-			ArrayList<TabletServerStatus> tserverStatusList = getTabletServers();
+			List<TabletServerStatus> tserverStatusList = getTabletServers();
 			List<TabletStats> tabletStatsList = getTabletStatsList(tserverStatusList,  tableNames);
 			retval = getNumberOfEntries_help(tabletStatsList);
 		} catch (D4mException | TException e) {
@@ -125,7 +125,7 @@ public class AccumuloTableOperations {
 
 		//Get TServers
 		try {
-			ArrayList<TabletServerStatus> tserverStatusList = getTabletServers();
+			List<TabletServerStatus> tserverStatusList = getTabletServers();
 			retval = getTabletStatsList(tserverStatusList,  tableNames);
 		} catch ( D4mException | TException e)  {
 			log.warn(e);    
@@ -244,7 +244,7 @@ public class AccumuloTableOperations {
 	 * Split table at partitions
 	 */
 	public void splitTable(String tableName, String[] partitions) {
-		TreeSet<Text> tset = new TreeSet<>();
+		SortedSet<Text> tset = new TreeSet<>();
 		for(String pt : partitions) {
 			tset.add(new Text(pt));
 		}

--- a/src/main/java/edu/mit/ll/d4m/db/cloud/accumulo/D4mDbQueryAccumulo.java
+++ b/src/main/java/edu/mit/ll/d4m/db/cloud/accumulo/D4mDbQueryAccumulo.java
@@ -30,7 +30,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -376,7 +378,7 @@ public class D4mDbQueryAccumulo extends D4mParentQuery {
 			String [] rowsArray = this.rowInfo.getContent();
 			this.rowKeys = param2keys(rowsArray);
 		}
-		HashMap<String, String> rowMap = this.rowStringMap;
+		Map<String, String> rowMap = this.rowStringMap;
 
 		D4mDbResultSet results = new D4mDbResultSet();
 		long start = System.currentTimeMillis();
@@ -530,7 +532,7 @@ public class D4mDbQueryAccumulo extends D4mParentQuery {
 		}
 		String[] rowArray = rowInfo.getContent();
 
-		HashSet<Range> ranges = new HashSet<Range>();
+		Set<Range> ranges = new HashSet<Range>();
 		if(!this.hasNext) {
 
 			if(this.bscanner == null)
@@ -1091,7 +1093,7 @@ public class D4mDbQueryAccumulo extends D4mParentQuery {
 		D4mDbResultSet resultSet = tool.doMatlabQuery(rows, cols);
 		double totalQueryTime = resultSet.getQueryTime();
 		System.out.println("totalQueryTime = " + totalQueryTime);
-		ArrayList<?> rowsArr = resultSet.getMatlabDbRow();
+		List<?> rowsArr = resultSet.getMatlabDbRow();
 
 		Iterator<?> it = rowsArr.iterator();
 		System.out.println("");
@@ -1193,7 +1195,7 @@ public class D4mDbQueryAccumulo extends D4mParentQuery {
 		this.connProps.setAuthorizations(authorizations);
 	}
 
-	public HashSet<Range> loadRanges(HashMap<String, String> queryMap) {
+	public HashSet<Range> loadRanges(Map<String, String> queryMap) {
 		HashSet<Range> ranges = new HashSet<Range>();
 		for (String rowId : queryMap.keySet()) {
 			//System.out.println("==>>ROW_ID="+rowId+"<<++");

--- a/src/main/java/edu/mit/ll/graphulo/ClientSideIteratorAggregatingScanner.java
+++ b/src/main/java/edu/mit/ll/graphulo/ClientSideIteratorAggregatingScanner.java
@@ -54,7 +54,7 @@ public class ClientSideIteratorAggregatingScanner extends ScannerOptions impleme
     }
     SortedKeyValueIterator<Key, Value> skvi = new MapIterator(allEntriesMap);
 
-    final TreeMap<Integer,IterInfo> tm = new TreeMap<>();
+    final SortedMap<Integer,IterInfo> tm = new TreeMap<>();
     for (IterInfo iterInfo : serverSideIteratorList) {
       tm.put(iterInfo.getPriority(), iterInfo);
     }

--- a/src/main/java/edu/mit/ll/graphulo/skvi/SmallLargeRowFilter.java
+++ b/src/main/java/edu/mit/ll/graphulo/skvi/SmallLargeRowFilter.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -39,8 +40,8 @@ public class SmallLargeRowFilter implements SortedKeyValueIterator<Key, Value>, 
   private SortedKeyValueIterator<Key, Value> source;
 
   // a cache of keys
-  private ArrayList<Key> keys = new ArrayList<>();
-  private ArrayList<Value> values = new ArrayList<>();
+  private List<Key> keys = new ArrayList<>();
+  private List<Value> values = new ArrayList<>();
 
   private int currentPosition;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.